### PR TITLE
Preventing often model downloads & adding pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Type of change
+
+- [ ] Refactor
+- [ ] New feature
+- [ ] Bug fix
+- [ ] Optimization
+- [ ] Documentation Update
+
+## Description
+
+<!--- Describe your changes in detail -->
+
+## Related Tickets & Documents
+
+- Related Issue #
+- Closes #
+
+## Checklist before requesting a review
+
+- [ ] I have performed a self-review of my code.
+- [ ] If it is a core feature, I have added thorough tests.
+
+## Testing
+- Please describe the System Under Test.
+- Please provide detailed steps to perform tests related to this code change.
+- How were the fix/results from this change verified? Please provide relevant screenshots or results.

--- a/src/inference.py
+++ b/src/inference.py
@@ -3,9 +3,19 @@ from PIL import Image
 from transformers import AutoModel, AutoTokenizer
 import logging
 import torch
+import os
 from torch.cuda.amp import autocast
 
 logger = logging.getLogger(__name__)
+
+# Define cache directory
+CACHE_DIR = "/app/transformers_cache"
+
+# Ensure the cache directory exists
+os.makedirs(CACHE_DIR, exist_ok=True)
+
+# Set environment variable to work in offline mode
+os.environ["TRANSFORMERS_OFFLINE"] = "1"
 
 def image_inference(each_panel: dict, args: tuple, return_dict: dict, idx: int) -> None:
     """
@@ -59,9 +69,9 @@ def image_inference(each_panel: dict, args: tuple, return_dict: dict, idx: int) 
     msgs = [{'role': 'user', 'content': input_prompt}]
 
     try:
-        model = AutoModel.from_pretrained('openbmb/MiniCPM-Llama3-V-2_5', trust_remote_code=True, torch_dtype=torch.float16)
+        model = AutoModel.from_pretrained('openbmb/MiniCPM-Llama3-V-2_5', cache_dir=CACHE_DIR, revision='e978c4c9b177e8d1f36deeec20edb18377dc2ff7', trust_remote_code=True, torch_dtype=torch.float16)
         model = model.to(device='cuda')
-        tokenizer = AutoTokenizer.from_pretrained('openbmb/MiniCPM-Llama3-V-2_5', trust_remote_code=True)
+        tokenizer = AutoTokenizer.from_pretrained('openbmb/MiniCPM-Llama3-V-2_5', cache_dir=CACHE_DIR, revision='e978c4c9b177e8d1f36deeec20edb18377dc2ff7', trust_remote_code=True)
         model.eval()
 
         # Use autocast for mixed precision to save memory

--- a/vqa-app/app/main.py
+++ b/vqa-app/app/main.py
@@ -12,6 +12,15 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI()
 
+# Define cache directory
+CACHE_DIR = "/app/transformers_cache"
+
+# Ensure the cache directory exists
+os.makedirs(CACHE_DIR, exist_ok=True)
+
+# Set environment variable to work in offline mode
+os.environ["TRANSFORMERS_OFFLINE"] = "1"
+
 @app.post("/inference/")
 async def inference(file: UploadFile = File(...), context: str = Form(""), query: str = Form("Can you summarize this image?")):
     file_location = f"/app/{file.filename}"
@@ -40,9 +49,9 @@ async def inference(file: UploadFile = File(...), context: str = Form(""), query
         msgs = [{'role': 'user', 'content': input_prompt}]
         response = ""
         try:
-            model = AutoModel.from_pretrained('openbmb/MiniCPM-Llama3-V-2_5', trust_remote_code=True, torch_dtype=torch.float16)
+            model = AutoModel.from_pretrained('openbmb/MiniCPM-Llama3-V-2_5', cache_dir=CACHE_DIR, revision='e978c4c9b177e8d1f36deeec20edb18377dc2ff7', trust_remote_code=True, torch_dtype=torch.float16)
             model = model.to(device='cuda')
-            tokenizer = AutoTokenizer.from_pretrained('openbmb/MiniCPM-Llama3-V-2_5', trust_remote_code=True)
+            tokenizer = AutoTokenizer.from_pretrained('openbmb/MiniCPM-Llama3-V-2_5', cache_dir=CACHE_DIR, revision='e978c4c9b177e8d1f36deeec20edb18377dc2ff7', trust_remote_code=True)
             model.eval()
 
             # Use autocast for mixed precision to save memory


### PR DESCRIPTION
### Description
Preventing often model downloads & adding pull request template

### Testing
Tested and verified by hosting model on DGX cluster
```
INFO:     Started server process [1]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
[2024-07-17 00:16:53,050] [INFO] [real_accelerator.py:203:get_accelerator] Setting ds_accelerator to cuda (auto detect)
df: /.triton/autotune: No such file or directory
 [WARNING]  async_io requires the dev libaio .so object and headers but these were not found.
 [WARNING]  async_io: please install the libaio-dev package with apt
 [WARNING]  If libaio is already installed (perhaps from source), try setting the CFLAGS and LDFLAGS environment variables to where it can be found.
 [WARNING]  Please specify the CUTLASS repo directory as environment variable $CUTLASS_PATH
 [WARNING]  NVIDIA Inference is only supported on Ampere and newer architectures
 [WARNING]  sparse_attn requires a torch version >= 1.5 and < 2.0 but detected 2.3
 [WARNING]  using untested triton version (2.3.1), only 1.0.0 is known to be compatible
Downloading shards:   0%|          | 0/7 [00:00<?, ?it/s]Downloading shards:  14%|█▍        | 1/7 [00:22<02:17, 22.95s/it]Downloading shards:  29%|██▊       | 2/7 [00:45<01:52, 22.59s/it]Downloading shards:  43%|████▎     | 3/7 [01:08<01:31, 22.76s/it]Downloading shards:  57%|█████▋    | 4/7 [01:31<01:08, 22.84s/it]Downloading shards:  71%|███████▏  | 5/7 [01:53<00:45, 22.68s/it]Downloading shards:
```